### PR TITLE
Docs update and decoding adjustment

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,7 +9,8 @@ This suite contains at the time of the writing, two major tools.
 
 link:/Fruneau/pfixtools/tree/master/pfix-srsd/pfix-srsd.asciidoc[+pfix-srsd+]::
     this daemon brings SRS to postfix using its
-    link:http://www.postfix.org/tcp_table.5.html[tcp_table(5)] mechanism. It
+    link:http://www.postfix.org/tcp_table.5.html[tcp_table(5)] or
+    link:http://www.postfix.org/socketmap_table.5.html[socketmap_table(5)] mechanisms. It
     allows plugging +SRS+ into
     link:http://www.postfix.org/canonical.5.html[canonical(5)] or
     link:http://www.postfix.org/transport.5.html[transport(5)] rewrites quite easily.
@@ -49,7 +50,7 @@ Supported platforms
 
 The pfixtools have been currently successfully compiled and installed on the following platorms:
 
-* Linux: gentoo, debian etch, debian lenny, arch linux
+* Linux: gentoo, debian etch, debian lenny, arch linux, centos 6.x
 * MacOS X 10.5 (Leopard), 10.6 (Snow Leopard)
 
 Known bugs:

--- a/pfix-srsd/main-srsd.c
+++ b/pfix-srsd/main-srsd.c
@@ -340,7 +340,7 @@ static int process_srs_socketmap(client_t *srsd, void* vconfig)
                     if (context->addrlen <= dlen || ibuf->data[context->addrlen - 1 - dlen] != '@' ||
                         memcmp(ibuf->data + context->addrlen - dlen, config->domain, dlen))
                     {
-                        netstring_send(obuf, 2, "OK ", ibuf->data);
+                        netstring_send(obuf, 1, "NOTFOUND External domains are ignored");
                         goto skip;
                     }
                 }
@@ -431,9 +431,7 @@ static int process_srs_tcp(client_t *srsd, void* vconfig)
                 if (q - p <= dlen || q[-1 - dlen] != '@' ||
                     memcmp(q - dlen, config->domain, dlen))
                 {
-                    buffer_addstr(obuf, "200 ");
-                    buffer_add(obuf, p, q - p);
-                    buffer_addch(obuf, '\n');
+                    buffer_addstr(obuf, "400 external domains are ignored\n");
                     goto skip;
                 }
             }

--- a/pfixtools.asciidoc
+++ b/pfixtools.asciidoc
@@ -23,11 +23,11 @@ This suite contains at the time of the writing, two major tools.
 
 linkgit:pfix-srsd[8,pfix-srsd/pfix-srsd.html]::
     this daemon brings SRS to postfix using its
-    linkgit:tcp_table[5,http://www.postfix.org/tcp_table.5.html] mechanism. It
+    link:http://www.postfix.org/tcp_table.5.html[tcp_table(5)] or
+    link:http://www.postfix.org/socketmap_table.5.html[socketmap_table(5)] mechanisms. It
     allows plugging +SRS+ into
-    linkgit:canonical[5,http://www.postfix.org/canonical.5.html] or
-    linkgit:transport[5,http://www.postfix.org/transport.5.html] rewrites
-    quite easily.
+    link:http://www.postfix.org/canonical.5.html[canonical(5)] or
+    link:http://www.postfix.org/transport.5.html[transport(5)] rewrites quite easily.
 
 linkgit:postlicyd[8,postlicyd/postlicyd.html]::
     this is a postfix policy daemon. It includes greylisting, rbl lookups,


### PR DESCRIPTION
Hi Fruneau,

I've adjusted the docs slightly to fix links and add references to the socketmap protocol capability.

More importantly, I found an issue with the use of canonical to decode. When ignoring external domains, it would return 200/OK with the same address as given, if the domain was external. However, if it was internal, and didn't need decoding, it would return 400/NOT FOUND Not an SRS address (due to the error return from srs_decode).

However, it seems that if a canonical rewrite returns OK, postfix will bypass local recipient checks. This means if someone tries to send to an address that would normally be rejected as "not in virtual mailbox table" for example, and it was considered external domain, we'd return an OK with the same address and cause that check to be bypassed. This meant the email would be accepted, and a bounce report generated.

So I've adjusted the decoder to always return NOT FOUND unless it did in fact decode something.

Thanks,

Jason
