### PR TITLE
400 is error - should be returning 500 which is not found

### DIFF
--- a/pfix-srsd/main-srsd.c
+++ b/pfix-srsd/main-srsd.c
@@ -431,7 +431,7 @@ static int process_srs_tcp(client_t *srsd, void* vconfig)
                 if (q - p <= dlen || q[-1 - dlen] != '@' ||
                     memcmp(q - dlen, config->domain, dlen))
                 {
-                    buffer_addstr(obuf, "400 external domains are ignored\n");
+                    buffer_addstr(obuf, "500 external domains are ignored\n");
                     goto skip;
                 }
             }


### PR DESCRIPTION
Looks like I got the code wrong there - it should be 500 to mean NOT FOUND. Otherwise with -I option it throws back 400 and postfix delays delivery thinking its a failure.

http://www.postfix.org/tcp_table.5.html
Has the codes.
