### PR TITLE
Fix build with unbound 1.6.1

### DIFF
--- a/postlicyd/dns.c
+++ b/postlicyd/dns.c
@@ -123,7 +123,7 @@ static int dns_handler(client_t *event, void *config)
 }
 
 bool dns_resolve(const char *hostname, dns_rrtype_t type,
-                 ub_callback_t callback, void *data)
+                 ub_callback_type callback, void *data)
 {
     if (_G.ctx == NULL) {
         _G.ctx = ub_ctx_create();

--- a/postlicyd/dns.h
+++ b/postlicyd/dns.h
@@ -89,7 +89,7 @@ typedef void (*dns_result_callback_f)(dns_result_t *result, void *data);
  */
 __attribute__((nonnull(1,3,4)))
 bool dns_resolve(const char *hostname, dns_rrtype_t type,
-                 ub_callback_t callback, void *data);
+                 ub_callback_type callback, void *data);
 
 /** Fetch the DNS record of the given type.
  */

--- a/postlicyd/spf-proto.c
+++ b/postlicyd/spf-proto.c
@@ -279,7 +279,7 @@ static bool spf_validate_domain(const char* restrict domain)
 }
 
 static bool spf_query(spf_t *spf, const char* query, dns_rrtype_t rtype,
-                      ub_callback_t cb)
+                      ub_callback_type cb)
 {
     buffer_reset(&_G.query_buffer);
     buffer_addstr(&_G.query_buffer, query);


### PR DESCRIPTION
From their changelog: Fix to rename ub_callback_t to ub_callback_type, because POSIX reserves _t typedefs